### PR TITLE
Fix padding for numbers which don't start with 1 (in binary)

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <meta property="og:description" content="Tupper's Self-Referential Formula, Self-Referential, Playgroud, Calculator">
 
     <link rel="stylesheet" type="text/css" href="index.css">
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js" defer></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js" defer></script>
     <script src="bignumber.min.js" defer></script>
     <script src="netpbm-parser/netpbm-parser.js" defer></script>
     <script src="numtowords.js" defer></script>

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var src = $('#grid');
 var wrap = $('<div id="grid-overlay"></div>');
 var gsize = 7;
+var grid = 1802;
 
 // these are 1 less due to counting from 0
 var cols = 105; // does not really matter
@@ -127,7 +128,7 @@ $('#decArea').keyup(function() {
     else if (input != "") {
         bigInput = new BigNumber(input);
         decError.text("");
-        setBitString(bigInput.dividedBy(17).floor().toString(2));
+        setBitString(bigInput.dividedBy(17).floor().toString(2).padStart(1802, 0));
         setDecString(bigInput);
         setBitMap();
     }


### PR DESCRIPTION
Some numbers, for example `k = 1788208905206181634939752552848166422283886449734190022256063240700777350574331846991191280892971878362181544521742658603550860229007774309200862140670562165266206055418188250035144314897761580517958703970638170418131757703652853453703582883219598402414863949502988123051643431490392385846613772183486267412412258102742205599571204888272440800224691311831678664887994182563289344934873969597122077226235329962019131650107808031441562804060123992411751668794714402239187184969399257970131604401315574185984` don't play nicely with the dec to binary conversion since quite a bit of data is lost (all of the leading zeros from the image). This ensures that the image is correct by padding it with the proper amount of zeros.

